### PR TITLE
workaround undefined meetings returned from query

### DIFF
--- a/src/panels/CourseList.tsx
+++ b/src/panels/CourseList.tsx
@@ -125,9 +125,13 @@ function DisplayCourses(state: CourseDisplayState, setCurrentState: (value: (((p
     for (const item of classes.nodes) {
         const meetings = [...item.meetings];
         meetings.sort((a, b) => a.meetingType - b.meetingType);
-        const mainMeeting = meetings[0];
+        const mainMeeting = meetings[0] || {
+            beginDate: null, beginTime: null, building: null,
+            endDate: null, endTime: null, inSession: null, meetingType: null, room: null
+        };
+
         let secondaryMeeting: Meeting | null = meetings[meetings.length - 1];
-        if (mainMeeting.meetingType === secondaryMeeting.meetingType) {
+        if (secondaryMeeting && mainMeeting.meetingType === secondaryMeeting.meetingType) {
             secondaryMeeting = null;
         }
 


### PR DESCRIPTION
There's some classes with undefined meeting times in management sciences apparently.
e.g. 

MIST-202-01
Fixes this. 

react-dom.production.min.js:189 TypeError: Cannot read properties of undefined (reading 'meetingType')
    at CourseList.tsx:130:25
    at rn (CourseList.tsx:176:21)
    at So (react-dom.production.min.js:167:137)
    at Ts (react-dom.production.min.js:197:258)
    at Su (react-dom.production.min.js:292:88)
    at wl (react-dom.production.min.js:280:389)
    at gl (react-dom.production.min.js:280:320)
    at ml (react-dom.production.min.js:280:180)
    at ol (react-dom.production.min.js:271:88)
    at al (react-dom.production.min.js:268:429)
ds @ react-dom.production.min.js:189
react-dom.production.min.js:283 Uncaught TypeError: Cannot read properties of undefined (reading 'meetingType')
    at CourseList.tsx:130:25
    at rn (CourseList.tsx:176:21)
    at So (react-dom.production.min.js:167:137)
    at Ts (react-dom.production.min.js:197:258)
    at Su (react-dom.production.min.js:292:88)
    at wl (react-dom.production.min.js:280:389)
    at gl (react-dom.production.min.js:280:320)
    at ml (react-dom.production.min.js:280:180)
    at ol (react-dom.production.min.js:271:88)
    at al (react-dom.production.min.js:268:429)
